### PR TITLE
The property editorElement is deprecated, element should be used.

### DIFF
--- a/lib/editor-integration.coffee
+++ b/lib/editor-integration.coffee
@@ -4,7 +4,7 @@ fs = require 'fs'
 
 posFromMouse = (editor, ev) ->
     screenPosition =
-        editor.editorElement.component.screenPositionForMouseEvent ev
+        editor.element.component.screenPositionForMouseEvent ev
     editor.bufferPositionForScreenPosition screenPosition
 
 cidentFromMouse = (ev) ->
@@ -117,7 +117,7 @@ class EditorIntegration
 
     _hookEditor: (ed) =>
         timeout = null
-        el = ed.editorElement
+        el = ed.element
         hover = (ev) =>
             try
                 cident = cidentFromMouse ev


### PR DESCRIPTION
Atom deprecation cop gives warnings about usage of deprecated property `editorElement` (which is a private property). This change replaces `editorElement` with `element` as sugested by the cop ...