### PR TITLE
Atom 1.19.2 rises a "TypeError: Cannot read property 'editorElement' of undefined"

### DIFF
--- a/lib/editor-integration.coffee
+++ b/lib/editor-integration.coffee
@@ -77,9 +77,9 @@ class EditorIntegration
             atom.notifications.addError(err.toString())
 
     _toggleBreakpoint: (ev) =>
-        editor = ev.currentTarget.component.editor
+        editor = ev.currentTarget.getModel()
         if ev.detail?[0].contextCommand
-            {row} = posFromMouse(ev.currentTarget.model, @ctxEvent)
+            {row} = posFromMouse(editor, @ctxEvent)
         else
             {row} = editor.getCursorBufferPosition()
         file = editor.getBuffer().getPath()


### PR DESCRIPTION
I tried to use the provided service `platformioIDEDebugger` in a  very simple Atom package ([this one](https://github.com/wendlers/atom-gdbtest)). In general I am able to start debugging, but when I try to toggle a breakpoint by using the right-click context menu, the type error shown below is thrown. It looks like the `editorElement` is not there as expected. At last it looks like so for _Atom 1.19.2_. Using `ev.currentTarget.getModel()` in `_toggleBreakpoint` instead of `ev.currentTarget.component.editor` seams to fix the problem. 

```
.../git/platformio-atom-ide-debugger/lib/editor-integration.coffee:7

TypeError: Cannot read property 'editorElement' of undefined
    at posFromMouse (/home/stefan/dev/git/platformio-atom-ide-debugger/lib/editor-integration.coffee:7:15)
    at EditorIntegration.module.exports.EditorIntegration._toggleBreakpoint (/home/stefan/dev/git/platformio-atom-ide-debugger/lib/editor-integration.coffee:82:21)
    at HTMLElement.<anonymous> (/home/stefan/dev/git/platformio-atom-ide-debugger/lib/editor-integration.coffee:1:1)
    at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/usr/share/atom/resources/app/src/command-registry.js:265:35)
    at CommandRegistry.handleCommandEvent (/usr/share/atom/resources/app/src/command-registry.js:3:65)
    at CommandRegistry.module.exports.CommandRegistry.dispatch (/usr/share/atom/resources/app/src/command-registry.js:166:25)
    at AtomEnvironment.module.exports.AtomEnvironment.dispatchContextMenuCommand (/usr/share/atom/resources/app/src/atom-environment.js:1344:34)
    at EventEmitter.outerCallback (/usr/share/atom/resources/app/src/application-delegate.js:347:31)
    at emitThree (events.js:116:13)
    at EventEmitter.emit (events.js:194:7)
```
