### PR TITLE
A command might fail, and thus not have a catch method. 

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -75,10 +75,13 @@ module.exports = PlatformIOIDEDebugger =
             @cliPanel.show()
 
     cmdWrap: (cmd) ->
-        cmd()
-            .catch (err) ->
-                atom.notifications.addError err.toString()
-
+        ret = cmd()
+        if ret.catch
+            ret
+                .catch (err) ->
+                  atom.notifications.addError err.toString()
+        else
+            atom.notifications.addError('Command failed. Lost connection / process terminated.')
     toggle: (panel, visibleFlag) ->
         if panel.isVisible()
             panel.hide()


### PR DESCRIPTION
This is e.g the case when the process which was debugged terminated. So for example if _not_ debugging on a embedded target but on a _normal_ Linux box for example, the target which is debugged might terminate (and no endless loop kepps it running). As soon as this happened, hitting e.g. the `play` button again leads to an exception stating 'catch' funciton is not there since it looks like in this situation the call to `cmd()` seams not to return a promise. So it might be a good idea to check if `catch` is available, and else give a notice to the user. 